### PR TITLE
added linebreaks at a configurable width to prevent text from overlapping the stream

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -159,7 +159,7 @@ local function load_twitch_chat(is_new_session)
                 end
             end
             -- force
-            if ((i + (offset//2)) % o.max_char_length) == 0 then
+            if ((i + math.floor(offset / 2)) % o.max_char_length) == 0 then
                 breakLine("-\n")
                 goto found_delimitor
             end


### PR DESCRIPTION
It also tries to find a suitable position to put a linebreak at. If it can't find one while approaching the maximum width, it will ungracefully add a linebreak like th-
is.
![Linebreaks](https://user-images.githubusercontent.com/22453965/175793848-53947b17-9e3e-4b4b-9950-781421483d3f.png)